### PR TITLE
test that json decode will overlay properly

### DIFF
--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -17,8 +17,10 @@
 package netdeploy
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,4 +96,22 @@ func TestValidate(t *testing.T) {
 	template, _ = loadTemplate(filepath.Join(templateDir, "TwoNodesOneRelay1000Accounts.json"))
 	err = template.Validate()
 	a.NoError(err)
+}
+
+type overlayTestStruct struct {
+	A string
+	B string
+}
+
+// TestJsonOverlay ensures that encoding/json will only clobber fields present in the json and leave other fields unchanged
+func TestJsonOverlay(t *testing.T) {
+	before := overlayTestStruct{A: "one", B: "two"}
+	setB := "{\"B\":\"other\"}"
+	dec := json.NewDecoder(strings.NewReader(setB))
+	after := before
+	err := dec.Decode(&after)
+	a := require.New(t)
+	a.NoError(err)
+	a.Equal("one", after.A)
+	a.Equal("other", after.B)
 }


### PR DESCRIPTION
The docs for `encoding/json` talk about what happens for json fields not in the struct, but doesn't actually promise to not touch fields in the struct that aren't in the json, so I wrote this test.